### PR TITLE
docs: fix typo in `getting-started/usage.mdx`

### DIFF
--- a/docs/src/content/docs/getting-started/usage.mdx
+++ b/docs/src/content/docs/getting-started/usage.mdx
@@ -85,7 +85,7 @@ Using utilities from `i18n:astro` on the client is opt-in. You need 2 things:
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="viewport" content="width=device-width" />
         <meta name="generator" content={Astro.generator} />
-        <I18NClient />
+        <I18nClient />
         <slot name="head" />
     </head>
     <body>


### PR DESCRIPTION
docs: fix typo in `getting-started/usage.mdx`