### PR TITLE
Fix trailing slash

### DIFF
--- a/.changeset/grumpy-sloths-shout.md
+++ b/.changeset/grumpy-sloths-shout.md
@@ -1,0 +1,5 @@
+---
+"@astrolicious/i18n": patch
+---
+
+Fixes an issue where locales would not be properly loaded depending on Astro `trailingSlash` value

--- a/package/assets/middleware.ts
+++ b/package/assets/middleware.ts
@@ -3,15 +3,15 @@ import { i18nextConfig, options, routes } from "virtual:astro-i18n/internal";
 import { defineMiddleware } from "astro/middleware";
 
 const extractLocaleFromUrl = (pathname: string) => {
-	for (const locale of options.locales) {
+	for (const locale of options.locales) { 
 		if (options.strategy === "prefix") {
-			if (pathname.startsWith(`/${locale}/`)) {
+			if (pathname.startsWith(`/${locale}/`)) { 
 				return locale;
 			}
 		} else if (options.strategy === "prefixExceptDefault") {
 			if (
 				locale !== options.defaultLocale &&
-				pathname.startsWith(`/${locale}/`)
+				pathname.startsWith(`/${locale}`)
 			) {
 				return locale;
 			}

--- a/package/assets/middleware.ts
+++ b/package/assets/middleware.ts
@@ -3,9 +3,9 @@ import { i18nextConfig, options, routes } from "virtual:astro-i18n/internal";
 import { defineMiddleware } from "astro/middleware";
 
 const extractLocaleFromUrl = (pathname: string) => {
-	for (const locale of options.locales) { 
+	for (const locale of options.locales) {
 		if (options.strategy === "prefix") {
-			if (pathname.startsWith(`/${locale}/`)) { 
+			if (pathname.startsWith(`/${locale}/`)) {
 				return locale;
 			}
 		} else if (options.strategy === "prefixExceptDefault") {

--- a/package/package.json
+++ b/package/package.json
@@ -38,10 +38,7 @@
 		"./components/I18nClient.astro": "./assets/components/I18nClient.astro",
 		"./components/I18nHead.astro": "./assets/components/I18nHead.astro"
 	},
-	"files": [
-		"dist",
-		"assets"
-	],
+	"files": ["dist", "assets"],
 	"scripts": {
 		"dev": "tsup --watch",
 		"build": "tsup"


### PR DESCRIPTION
Hi @florian-lefebvre, I believe I have found a fix for #24.

The problem was only ever happening on the root of a locale without a trailing slash.
F.ex. `http://localhost:4322/fr`. 

So I remove the trailing slash in the middleware.