### PR TITLE
Fixes matching of similar dynamic parameters

### DIFF
--- a/.changeset/red-lies-play.md
+++ b/.changeset/red-lies-play.md
@@ -2,4 +2,4 @@
 "@astrolicious/i18n": patch
 ---
 
-Fix incorrect matching second dynamic route
+Fixes matching of similar dynamic parameters

--- a/.changeset/red-lies-play.md
+++ b/.changeset/red-lies-play.md
@@ -1,0 +1,5 @@
+---
+"@astrolicious/i18n": patch
+---
+
+Fix incorrect matching second dynamic route

--- a/playground/src/layouts/Layout.astro
+++ b/playground/src/layouts/Layout.astro
@@ -30,6 +30,7 @@ const { title } = Astro.props;
         <a href={getLocalePath("/")}>{t("home:title")}</a>
         <a href={getLocalePath("/about")}>{t("about")}</a>
         <a href={getLocalePath("/blog")}>{t("blog")}</a>
+        <a href={getLocalePath("/user")}>{t("user")}</a>
       </div>
       <LocaleSwitcher />
     </header>

--- a/playground/src/locales/en/common.json
+++ b/playground/src/locales/en/common.json
@@ -1,5 +1,6 @@
 {
 	"home": "Home",
 	"about": "About",
-	"blog": "The blog"
+	"blog": "The blog",
+	"user": "The user"
 }

--- a/playground/src/locales/fr/common.json
+++ b/playground/src/locales/fr/common.json
@@ -1,5 +1,6 @@
 {
 	"home": "Accueil",
 	"about": "A propos",
-	"blog": "Le blog"
+	"blog": "Le blog",
+	"user": "Utilisateur"
 }

--- a/playground/src/routes/user.astro
+++ b/playground/src/routes/user.astro
@@ -1,0 +1,32 @@
+---
+import { getLocale, getLocalePath, t } from "i18n:astro";
+import Layout from "~/layouts/Layout.astro";
+
+const title = t("user");
+
+const slugs = [
+	{
+		en: "a",
+		fr: "d",
+	},
+	{
+		en: "b",
+		fr: "e",
+	},
+	{
+		en: "c",
+		fr: "f",
+	},
+];
+
+const currentLocaleSlugs = slugs.map((e) => e[getLocale()]);
+---
+
+<Layout {title}>
+  <h1>{title}</h1>
+  {
+    currentLocaleSlugs.map((slug) => (
+      <a href={getLocalePath("/user/[slug]", { slug })} class="block p-1 underline">{slug}</a>
+    ))
+  }
+</Layout>

--- a/playground/src/routes/user/[slug].astro
+++ b/playground/src/routes/user/[slug].astro
@@ -1,0 +1,63 @@
+---
+import {
+	getDefaultLocalePlaceholder,
+	getLocalePlaceholder,
+	getLocalesPlaceholder,
+	setDynamicParams,
+	t,
+} from "i18n:astro";
+import sitemap from "i18n:astro/sitemap";
+import type { GetStaticPaths } from "astro";
+import Layout from "~/layouts/Layout.astro";
+
+export const getStaticPaths = (() => {
+	const locale = getLocalePlaceholder();
+	const locales = getLocalesPlaceholder();
+	const defaultLocale = getDefaultLocalePlaceholder();
+	console.log({ locale, locales, defaultLocale });
+
+	const slugs = [
+		{
+			en: "a",
+			fr: "d",
+		},
+		{
+			en: "b",
+			fr: "e",
+		},
+		{
+			en: "c",
+			fr: "f",
+		},
+	];
+
+	return slugs.map((slug) => {
+		const dynamicParams = Object.entries(slug).map(([locale, slug]) => ({
+			locale,
+			params: { slug },
+		}));
+		sitemap({
+			dynamicParams,
+		});
+		return {
+			params: {
+				slug: slug[locale],
+			},
+			props: {
+				dynamicParams,
+			},
+		};
+	});
+}) satisfies GetStaticPaths;
+
+const { slug } = Astro.params;
+const { dynamicParams } = Astro.props;
+
+setDynamicParams(dynamicParams);
+
+const title = t("user");
+---
+
+<Layout {title}>
+  <h1>{title} {slug}</h1>
+</Layout>


### PR DESCRIPTION
### Describe Bug

If I have below dynamic routes:

* `/blog/[slug]`
* `/user/[slug]`

When I change the language selector from above both routes, I'll always return the `/blog/[slug]`.

### Description

Original method to find the dynemic route is not working for finding two (or more) dynamic routes, because it just compare the route params keys (like `slug`) and return the first one:

https://github.com/astrolicious/i18n/blob/46686bd2fc05c6b5dee4818aae0be21a04ef9ab4/package/assets/stubs/virtual.mjs#L240-L246

If I have below dynamic routes:

* `/blog/[slug]`
* `/user/[slug]`

It will always return the `/blog/[slug]` because it's the first one.

So I've changed to the RegExp to match the dynamic routes.

### Testing

I've add the `/user/[slug]` route into the playground.

You can follow the steps below to test:

1. Clone the repo with this PR
2. Compile the package and open the playground
3. Visit http://localhost:4321/user/a
4. Change the language selector to `fr` and you'll see the `/user/[slug]` route is returned
5. If you revert the patch code back to orignal and repeat the steps, you'll see the `/blog/[slug]` route is returned
